### PR TITLE
Implement web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # To-Do List Application
 
-This is a simple command-line to-do list application implemented in Python using the MVC architecture.
+This is a simple web-based to-do list application implemented in Python using FastAPI and the MVC architecture.
 
 ## Usage
 
 Run the application with:
 
 ```bash
-python main.py
+uvicorn main:app --reload
 ```
 
-Available commands:
+Open your browser at `http://localhost:8000/` to use the web interface.
 
-- `add` – Add a new task
-- `list` – List all tasks
-- `complete` – Mark a task as completed
-- `delete` – Delete a task
-- `quit` – Exit the application
+The API exposes the following endpoints:
+
+- `POST /tasks` – Add a new task
+- `GET /tasks` – List all tasks
+- `PUT /tasks/{index}/complete` – Mark a task as completed
+- `DELETE /tasks/{index}` – Delete a task

--- a/controllers/task_controller.py
+++ b/controllers/task_controller.py
@@ -7,16 +7,16 @@ class TaskController:
 
     def add(self, description):
         self.model.add_task(description)
-        self.view.display_message("Task added.")
+        return self.view.display_message("Task added.")
 
     def list(self):
         tasks = self.model.list_tasks()
-        self.view.display_tasks(tasks)
+        return self.view.display_tasks(tasks)
 
     def complete(self, index):
         self.model.complete_task(index)
-        self.view.display_message("Task completed.")
+        return self.view.display_message("Task completed.")
 
     def delete(self, index):
         self.model.delete_task(index)
-        self.view.display_message("Task deleted.")
+        return self.view.display_message("Task deleted.")

--- a/controllers/web_task_controller.py
+++ b/controllers/web_task_controller.py
@@ -1,0 +1,17 @@
+class WebTaskController:
+    """Controller used by the HTML interface."""
+
+    def __init__(self, model):
+        self.model = model
+
+    def add(self, description):
+        self.model.add_task(description)
+
+    def list(self):
+        return self.model.list_tasks()
+
+    def complete(self, index):
+        self.model.complete_task(index)
+
+    def delete(self, index):
+        self.model.delete_task(index)

--- a/main.py
+++ b/main.py
@@ -1,37 +1,62 @@
+from fastapi import FastAPI, Request, Form
+from fastapi.responses import RedirectResponse, HTMLResponse
+from pydantic import BaseModel
+
 from controllers.task_controller import TaskController
+from controllers.web_task_controller import WebTaskController
 from models.task_model import TaskModel
 from views.task_view import TaskView
+from views.task_web_view import TaskWebView
+
+app = FastAPI()
+
+model = TaskModel()
+view = TaskView()
+controller = TaskController(model, view)
+web_view = TaskWebView()
+web_controller = WebTaskController(model)
+
+class TaskCreate(BaseModel):
+    description: str
+
+@app.post("/tasks")
+def add_task(task: TaskCreate):
+    return controller.add(task.description)
+
+@app.get("/tasks")
+def list_tasks():
+    return controller.list()
+
+@app.put("/tasks/{index}/complete")
+def complete_task(index: int):
+    return controller.complete(index)
+
+@app.delete("/tasks/{index}")
+def delete_task(index: int):
+    return controller.delete(index)
 
 
-def main():
-    model = TaskModel()
-    view = TaskView()
-    controller = TaskController(model, view)
+# Web interface routes
 
-    while True:
-        command = input("Enter command (add/list/complete/delete/quit): ").strip()
-        if command == "add":
-            description = input("Task description: ")
-            controller.add(description)
-        elif command == "list":
-            controller.list()
-        elif command == "complete":
-            try:
-                index = int(input("Task number to complete: ")) - 1
-                controller.complete(index)
-            except ValueError:
-                view.display_message("Invalid number.")
-        elif command == "delete":
-            try:
-                index = int(input("Task number to delete: ")) - 1
-                controller.delete(index)
-            except ValueError:
-                view.display_message("Invalid number.")
-        elif command == "quit":
-            break
-        else:
-            view.display_message("Unknown command.")
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request):
+    tasks = web_controller.list()
+    return web_view.display_tasks(request, tasks)
 
 
-if __name__ == "__main__":
-    main()
+@app.post("/add")
+def add_task_form(description: str = Form(...)):
+    web_controller.add(description)
+    return RedirectResponse("/", status_code=303)
+
+
+@app.post("/complete/{index}")
+def complete_task_form(index: int):
+    web_controller.complete(index)
+    return RedirectResponse("/", status_code=303)
+
+
+@app.post("/delete/{index}")
+def delete_task_form(index: int):
+    web_controller.delete(index)
+    return RedirectResponse("/", status_code=303)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>To-Do List</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        form { margin-bottom: 1em; }
+        li.completed { text-decoration: line-through; color: gray; }
+    </style>
+</head>
+<body>
+    <h1>To-Do List</h1>
+    <form action="/add" method="post">
+        <input type="text" name="description" placeholder="New task" required>
+        <button type="submit">Add</button>
+    </form>
+    <ul>
+        {% for task in tasks %}
+            <li class="{% if task.completed %}completed{% endif %}">
+                {{ task.description }}
+                {% if not task.completed %}
+                    <form action="/complete/{{ loop.index0 }}" method="post" style="display:inline">
+                        <button type="submit">Complete</button>
+                    </form>
+                {% endif %}
+                <form action="/delete/{{ loop.index0 }}" method="post" style="display:inline">
+                    <button type="submit">Delete</button>
+                </form>
+            </li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/views/task_view.py
+++ b/views/task_view.py
@@ -1,13 +1,10 @@
 class TaskView:
-    """Handles displaying information to the user."""
+    """Handles formatting of responses."""
 
     def display_tasks(self, tasks):
-        if not tasks:
-            print("No tasks found.")
-            return
-        for i, task in enumerate(tasks):
-            status = "[x]" if task.get("completed") else "[ ]"
-            print(f"{i + 1}. {status} {task.get('description')}")
+        """Return the list of tasks to the client."""
+        return tasks
 
     def display_message(self, message):
-        print(message)
+        """Return a simple message to the client."""
+        return {"message": message}

--- a/views/task_web_view.py
+++ b/views/task_web_view.py
@@ -1,0 +1,10 @@
+from fastapi.templating import Jinja2Templates
+from fastapi.requests import Request
+
+templates = Jinja2Templates(directory="templates")
+
+class TaskWebView:
+    """Render tasks to HTML pages."""
+
+    def display_tasks(self, request: Request, tasks):
+        return templates.TemplateResponse("index.html", {"request": request, "tasks": tasks})


### PR DESCRIPTION
## Summary
- add HTML-based web front-end using FastAPI templates
- create `TaskWebView` and `WebTaskController`
- serve new routes for HTML pages
- document how to access the UI

## Testing
- `python -m py_compile main.py controllers/task_controller.py controllers/web_task_controller.py views/task_view.py views/task_web_view.py models/task_model.py`
- `python - <<'PY'
import main
print(type(main.app))
PY` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6842393883f8832eab80f71337315e2b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a web-based to-do list application with a user-friendly HTML interface.
  - Added REST API endpoints for adding, listing, completing, and deleting tasks.
- **Documentation**
  - Updated the README to reflect the new web interface, usage instructions, and available API endpoints.
- **Chores**
  - Added a requirements file specifying necessary dependencies for running the web application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->